### PR TITLE
fix: repair expired doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ func main() {
     }
 
     // 监听哪类事件就需要实现哪类的 handler，定义：websocket/event_handler.go
-    var atMessage websocket.ATMessageEventHandler = func(event *dto.WSPayload, data *dto.WSATMessageData) error {
+    var atMessage event.ATMessageEventHandler = func(event *dto.WSPayload, data *dto.WSATMessageData) error {
         fmt.Println(event, data)
         return nil
     }


### PR DESCRIPTION
尝试使用本段代码时发现问题：

websocket 包下没有 ATMessageEventHandler，该关键字在 event 包下，提交此修复。