### PR TITLE
fix(openapi): fix auth scheme loss in OnBeforeRequest hook

### DIFF
--- a/openapi/v1/openapi.go
+++ b/openapi/v1/openapi.go
@@ -95,15 +95,15 @@ func (o *openAPI) setupClient(appID string) {
 			},
 		).
 		OnBeforeRequest(
-			func(c *resty.Client, _ *resty.Request) error {
+			func(_ *resty.Client, r *resty.Request) error {
 				tk, err := o.tokenSource.Token()
 				if err != nil {
 					log.Errorf("[setupClient] retrieve token failed:%s", err)
 					return err
 				}
-				c.SetAuthScheme(tk.TokenType)
+				r.SetAuthScheme(tk.TokenType)
 				log.Debugf("token type:%s", tk.TokenType)
-				c.SetAuthToken(tk.AccessToken)
+				r.SetAuthToken(tk.AccessToken)
 				return nil
 			},
 		).


### PR DESCRIPTION
### bug 现象
当项目将底层间接依赖 `github.com/go-resty/resty/v2` 升级至较高版本（如 `v2.17.2`）时，机器人发起的**首次 API 请求会稳定复现 500 错误**（报错体：`{"message": "fetch robot info failed", "code": 340067}`）。而之后的请求正常。

通过日志发现，首次请求的请求头中，认证体为：`Authorization: Bearer`，而能正常发送的认证体为：`Authorization: QQBot`。高版本 `go-resty` 在首次请求时，默认回退使用了 `Bearer` 作为 Authorization Scheme。

### 原因

问题出在 `openapi/v1/openapi.go` 的 `setupClient` 函数中的 `OnBeforeRequest` 钩子设计上：

1. 在现有的逻辑中，Hook 试图通过 `c.SetAuthScheme(tk.TokenType)` 来挂载鉴权。但在高版本的 `go-resty` 中，行为有所不同，此时修改全局的 `Client (c)`，不会影响当前正在发出的这个 `Request` 的 `TokenType`，导致当前请求鉴权失败。
2. 现有的写法在 Hook 中动态修改了全局单例的 `c *resty.Client`。可能存在多个并发请求同时修改全局 Client 的属性，存在数据竞争隐患。